### PR TITLE
Expand testing to later python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,6 @@ dist: xenial  # required for Python >= 3.7
 language: python
 matrix:
   include:
-    - python: 3.5
-      env:
-         - TOX_ENV=flake8
-         - TOX_ENV=isort
-         - TOX_ENV=pydocstyle
-         - TOX_ENV=py35
     - python: 3.6
       env:
          - TOX_ENV=flake8
@@ -21,7 +15,7 @@ matrix:
          - TOX_ENV=isort
          - TOX_ENV=pydocstyle
          - TOX_ENV=py37
-    - python: 3.8
+    - python: 3.8-dev
       env:
          - TOX_ENV=flake8
          - TOX_ENV=isort

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: xenial  # required for Python >= 3.7
 language: python
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,22 +5,13 @@ matrix:
   include:
     - python: 3.6
       env:
-         - TOX_ENV=flake8
-         - TOX_ENV=isort
-         - TOX_ENV=pydocstyle
-         - TOX_ENV=py36
+         - TOX_ENV=travis
     - python: 3.7
       env:
-         - TOX_ENV=flake8
-         - TOX_ENV=isort
-         - TOX_ENV=pydocstyle
-         - TOX_ENV=py37
+         - TOX_ENV=travis
     - python: 3.8-dev
       env:
-         - TOX_ENV=flake8
-         - TOX_ENV=isort
-         - TOX_ENV=pydocstyle
-         - TOX_ENV=py38
+         - TOX_ENV=travis
 install:
  - pip install codecov
  - pip install tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,31 @@
 sudo: false
 language: python
-python:
- - "3.5"
- - "3.6"
- - "3.7"
- - "3.8"
-env:
- - TOX_ENV=flake8
- - TOX_ENV=isort
- - TOX_ENV=pydocstyle
- - TOX_ENV=py36
+matrix:
+  include:
+    - python: 3.5
+      env:
+         - TOX_ENV=flake8
+         - TOX_ENV=isort
+         - TOX_ENV=pydocstyle
+         - TOX_ENV=py35
+    - python: 3.6
+      env:
+         - TOX_ENV=flake8
+         - TOX_ENV=isort
+         - TOX_ENV=pydocstyle
+         - TOX_ENV=py36
+    - python: 3.7
+      env:
+         - TOX_ENV=flake8
+         - TOX_ENV=isort
+         - TOX_ENV=pydocstyle
+         - TOX_ENV=py37
+    - python: 3.8
+      env:
+         - TOX_ENV=flake8
+         - TOX_ENV=isort
+         - TOX_ENV=pydocstyle
+         - TOX_ENV=py38
 install:
  - pip install codecov
  - pip install tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 sudo: false
 language: python
 python:
+ - "3.5"
  - "3.6"
+ - "3.7"
+ - "3.8"
 env:
  - TOX_ENV=flake8
  - TOX_ENV=isort

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setuptools.setup(
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,isort,pydocstyle,py36,py37,py38
+envlist = flake8,isort,pydocstyle,py36,py37,py38,travis
 skipsdist=true
 
 [testenv]
@@ -38,3 +38,10 @@ commands = pydocstyle
 [pydocstyle]
 match-dir = runeberg
 match = (?![test_|__init__]).*\.py
+
+[testenv:travis]
+commands =
+    nosetests tests/
+    flake8
+    isort --check-only --diff --recursive --verbose --skip .tox --skip .git --skip build
+    pydocstyle

--- a/tox.ini
+++ b/tox.ini
@@ -20,16 +20,8 @@ ignore = E501,W503
 [testenv:isort]
 deps = isort==4.2.15
 commands =
-    bash -c "find {toxinidir} \
-        -type d \
-            \( \
-              -path {toxinidir}/.git -o \
-              -path {toxinidir}/.tox -o \
-              -path {toxinidir}/.venv -o \
-              -path {toxinidir}/vendor \
-            \) -prune -o \
-        -name '*.py' \
-        -print | xargs isort {posargs:--check-only} --verbose"
+    isort --check-only --diff --recursive --verbose \
+        --skip .tox --skip .git --skip build --dont-skip __init__.py
 
 [testenv:pydocstyle]
 deps = pydocstyle
@@ -41,7 +33,8 @@ match = (?![test_|__init__]).*\.py
 
 [testenv:travis]
 commands =
-    nosetests tests/
     flake8
-    isort --check-only --diff --recursive --verbose --skip .tox --skip .git --skip build
+    isort --check-only --diff --recursive --skip .tox --skip .git --skip build
     pydocstyle
+    nosetests tests/
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,isort,pydocstyle,py35,py36,py37,py38
+envlist = flake8,isort,pydocstyle,py36,py37,py38
 skipsdist=true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ commands = pydocstyle
 match-dir = runeberg
 match = (?![test_|__init__]).*\.py
 
-[testenv:travis]
+[testenv:travis]  # combined testing to be run per python version
 commands =
     flake8
     isort --check-only --diff --recursive --skip .tox --skip .git --skip build

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,isort,pydocstyle,py36
+envlist = flake8,isort,pydocstyle,py35,py36,py37,py38
 skipsdist=true
 
 [testenv]


### PR DESCRIPTION
Expands travis testing to py37, py38-dev while stil providing smaller testing
environments for local testing.

Also compacts the isort command.