### PR TITLE
Introduce .text in Article and Work

### DIFF
--- a/runeberg/article.py
+++ b/runeberg/article.py
@@ -16,6 +16,7 @@ advertisement might interrupt it.
 Note that some entries in Articles.lst are only used as Table of Content
 headers, as such they should not be treated as proper articles.
 """
+# @TODO: Handle sub-articles. See e.g. "register" http://runeberg.org/aoshbok/
 from bs4 import BeautifulSoup
 
 from runeberg.page_range import PageRange
@@ -83,6 +84,11 @@ class Article(object):
             text = soup.get_text()
             self._clean_title = text.strip()
         return self._clean_title
+
+    @property
+    def text(self):
+        """Return all the text of the article."""
+        return '\n'.join([page.text for page in self.pages])
 
     @property
     def uid(self):

--- a/runeberg/page_range.py
+++ b/runeberg/page_range.py
@@ -49,6 +49,11 @@ class PageRange(OrderedDict):
         else:
             return '{}-{}'.format(key_list[0], key_list[-1])
 
+    @property
+    def text(self):
+        """Return the text from all the pages in the range."""
+        return '\n'.join([page.text for page in self.values()])
+
     # not implemented in __getitem__ to avoid it mixing keys and indexes
     # at the cost of a bulkier syntax
     def slice(self, start=None, stop=None, step=None):

--- a/runeberg/work.py
+++ b/runeberg/work.py
@@ -72,6 +72,11 @@ class Work(object):
         work.parse_people(known_people)
         return work
 
+    @property
+    def text(self):
+        """Return all the text of the work."""
+        return '\n'.join([page.text for page in self.pages])
+
     def runeberg_url(self):
         """Return the base url on runeberg.org."""
         return '{0}/{1}/'.format(SITE, self.uid)

--- a/runeberg/work.py
+++ b/runeberg/work.py
@@ -75,7 +75,7 @@ class Work(object):
     @property
     def text(self):
         """Return all the text of the work."""
-        return '\n'.join([page.text for page in self.pages])
+        return '\n'.join([page.text for page in self.pages.values()])
 
     def runeberg_url(self):
         """Return the base url on runeberg.org."""

--- a/runeberg/work.py
+++ b/runeberg/work.py
@@ -75,7 +75,7 @@ class Work(object):
     @property
     def text(self):
         """Return all the text of the work."""
-        return '\n'.join([page.text for page in self.pages.values()])
+        return self.pages.text
 
     def runeberg_url(self):
         """Return the base url on runeberg.org."""

--- a/tests/test_article.py
+++ b/tests/test_article.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 """Unit tests for article."""
 import unittest
+import unittest.mock as mock
 
 from runeberg.article import Article
 from runeberg.page import Page
+from runeberg.page_range import PageRange
 
 
 class TestIsTocHeader(unittest.TestCase):
@@ -49,3 +51,35 @@ class TestUid(unittest.TestCase):
     def test_uid_with_disambig(self):
         self.article.disambig = 2
         self.assertEqual(self.article.uid, 'Genesis (2)')
+
+
+class TestText(unittest.TestCase):
+
+    def setUp(self):
+        self.article = Article('Genesis')
+        # cannot get instance attribute mocking to work for page
+        self.page = Page('page_1', text='This is the page text.')
+        self.page_range = PageRange([])
+
+        patcher = mock.patch('runeberg.page_range.PageRange.text',
+                             new_callable=mock.PropertyMock)
+        self.mock_page_range_text = patcher.start()
+        self.mock_page_range_text.return_value = 'This is the page_range text.'
+        self.addCleanup(patcher.stop)
+
+    def test_text_no_pages(self):
+        self.assertEqual(self.article.text, '')
+
+    def test_text_page(self):
+        self.article.pages = [self.page]
+        self.assertEqual(self.article.text, 'This is the page text.')
+
+    def test_text_page_range(self):
+        self.article.pages = [self.page_range]
+        self.assertEqual(self.article.text, 'This is the page_range text.')
+
+    def test_text_multiple_pages(self):
+        self.article.pages = [self.page, self.page_range]
+        self.assertEqual(
+            self.article.text,
+            'This is the page text.\nThis is the page_range text.')

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -24,11 +24,11 @@ class TestGetChapters(unittest.TestCase):
         self.page = Page('0001')
 
     def test_get_chapters_empty(self):
-        self.page.ocr = ''
+        self.page.text = ''
         self.assertEqual(self.page.get_chapters(), [])
 
     def test_get_chapters_no_chapters(self):
-        self.page.ocr = (
+        self.page.text = (
             'row 1\n'
             'row 2\n'
             'row3'
@@ -36,7 +36,7 @@ class TestGetChapters(unittest.TestCase):
         self.assertEqual(self.page.get_chapters(), [])
 
     def test_get_chapters_unique_chapters(self):
-        self.page.ocr = (
+        self.page.text = (
             'row 1\n'
             'pre<chapter name="chp1">post\n'
             'row 2\n'
@@ -47,7 +47,7 @@ class TestGetChapters(unittest.TestCase):
         self.assertEqual(self.page.get_chapters(), expected)
 
     def test_get_chapters_non_unique_chapters(self):
-        self.page.ocr = (
+        self.page.text = (
             'row 1\n'
             'pre<chapter name="chp1">post\n'
             'row 2\n'
@@ -59,7 +59,7 @@ class TestGetChapters(unittest.TestCase):
         self.assertEqual(self.page.get_chapters(), expected)
 
     def test_get_chapters_missing_attribute(self):
-        self.page.ocr = (
+        self.page.text = (
             'row 1\n'
             'pre<chapter>post\n'
             'row 2\n'
@@ -79,10 +79,10 @@ class TestRenameChapter(unittest.TestCase):
             'row 2\n'
             'row3'
         )
-        self.page = Page('0001', ocr=text)
+        self.page = Page('0001', text=text)
 
     def test_rename_chapter_no_chapter(self):
-        self.page.ocr = (
+        self.page.text = (
             'row 1\n'
             'row 2\n'
             'row3'
@@ -93,10 +93,10 @@ class TestRenameChapter(unittest.TestCase):
             'row3'
         )
         self.page.rename_chapter('chp1', 'foo')
-        self.assertEqual(self.page.ocr, expected)
+        self.assertEqual(self.page.text, expected)
 
     def test_rename_chapter_single_match(self):
-        self.page.ocr = (
+        self.page.text = (
             'row 1\n'
             'pre<chapter name="chp1">post\n'
             'row 2\n'
@@ -111,10 +111,10 @@ class TestRenameChapter(unittest.TestCase):
             'row3'
         )
         self.page.rename_chapter('chp2', 'foo')
-        self.assertEqual(self.page.ocr, expected)
+        self.assertEqual(self.page.text, expected)
 
     def test_rename_chapter_multiple_matches(self):
-        self.page.ocr = (
+        self.page.text = (
             'row 1\n'
             'pre<chapter name="chp1">post\n'
             'row 2\n'
@@ -131,7 +131,7 @@ class TestRenameChapter(unittest.TestCase):
             'pre<chapter name="chp1">post\n'
         )
         self.page.rename_chapter('chp1', 'foo')
-        self.assertEqual(self.page.ocr, expected)
+        self.assertEqual(self.page.text, expected)
 
 
 class TestCheckBlank(unittest.TestCase):
@@ -144,23 +144,23 @@ class TestCheckBlank(unittest.TestCase):
             'row 2\n'
             'row3'
         )
-        self.page = Page('0001', ocr=text)
+        self.page = Page('0001', text=text)
 
     @unittest.expectedFailure  # hack to assert not Warns
     def test_check_blank_empty_and_blank(self):
-        self.page.ocr = ''
+        self.page.text = ''
         self.page.is_proofread = None
         with self.assertWarnsRegex(UserWarning, r'is blank'):
             self.page.check_blank()
 
     def test_check_blank_empty_and_proofread(self):
-        self.page.ocr = ''
+        self.page.text = ''
         self.page.is_proofread = True
         with self.assertWarnsRegex(UserWarning, r'is blank'):
             self.page.check_blank()
 
     def test_check_blank_empty_and_not_proofread(self):
-        self.page.ocr = ''
+        self.page.text = ''
         self.page.is_proofread = False
         with self.assertWarnsRegex(UserWarning, r'might be blank'):
             self.page.check_blank()

--- a/tests/test_page_range.py
+++ b/tests/test_page_range.py
@@ -2,6 +2,7 @@
 """Unit tests for page_range."""
 import unittest
 
+from runeberg.page import Page
 from runeberg.page_range import PageRange
 
 
@@ -113,3 +114,19 @@ class TestLast(BaseTest):
 
     def test_last(self):
         self.assertEqual(self.pages.last(), 1)
+
+
+class TestText(unittest.TestCase):
+
+    """Test the text property."""
+
+    def test_text_empty(self):
+        pages = PageRange([])
+        self.assertEqual(pages.text, '')
+
+    def test_text(self):
+        pages = PageRange([
+            ('one', Page('page_1', text='text_1')),
+            ('two', Page('page_2', text='text_2')),
+            ('three', Page('page_3', text='text_3'))])
+        self.assertEqual(pages.text, 'text_1\ntext_2\ntext_3')

--- a/tests/test_work.py
+++ b/tests/test_work.py
@@ -193,7 +193,7 @@ class TestLoadArticle(unittest.TestCase):
 
         patcher = mock.patch('runeberg.work.Work.parse_range')
         self.mock_parse_range = patcher.start()
-        self.mock_parse_range.return_value = [Page('0001', ocr='abc')]
+        self.mock_parse_range.return_value = [Page('0001', text='abc')]
         self.addCleanup(patcher.stop)
 
         patcher = mock.patch('runeberg.page.Page.rename_chapter')
@@ -321,9 +321,9 @@ class TestLoadArticle(unittest.TestCase):
         self.mock_disambiguation_counter.return_value = Counter({'A': 1})
         self.mock_get_chapters.return_value = ['A']
         self.mock_parse_range.return_value = [
-            Page('0001', ocr='abc'),
-            Page('0002', ocr='abc'),
-            Page('0003', ocr='abc')]
+            Page('0001', text='abc'),
+            Page('0002', text='abc'),
+            Page('0003', text='abc')]
 
         with self.assertRaises(ReconciliationError):
             self.work.load_articles(self.base_path, chapters,

--- a/tests/test_work.py
+++ b/tests/test_work.py
@@ -418,3 +418,20 @@ class TestDetermineImageFileType(unittest.TestCase):
 
         self.work.determine_image_file_type('base', 'img')
         self.assertEquals(self.work.image_type, '.jpg')
+
+
+class TestText(unittest.TestCase):
+
+    """Unit tests for text property."""
+
+    def setUp(self):
+        self.work = Work('uid')
+
+    def test_text_no_pages(self):
+        self.assertEqual(self.work.text, '')
+
+    def test_text(self):
+        with mock.patch('runeberg.page_range.PageRange.text',
+                        new_callable=mock.PropertyMock) as mock_pagerange_text:
+            mock_pagerange_text.return_value = 'text in the page range'
+            self.assertEqual(self.work.text, 'text in the page range')


### PR DESCRIPTION
Adds `text` property to `Article` and `Work` while also relabelling the `Page.ocr`
property to `Page.text` for consistency.

Fixes #18
Fixes #19